### PR TITLE
Container name update 2Thooq --> 3baos1

### DIFF
--- a/BetterDiscord-Themes/Modules/transparency2.css
+++ b/BetterDiscord-Themes/Modules/transparency2.css
@@ -16,7 +16,7 @@
 }
 
 /* transparency for channels and members list and private channels and left side of settings*/
-.container-PNkimc, .privateChannels-1nO12o, .da-app .sidebarRegion-VFTUkN, .da-app .container-2Thooq {
+.container-PNkimc, .privateChannels-1nO12o, .da-app .sidebarRegion-VFTUkN, .da-app .container-3baos1 {
 	background: transparent;
 	background-image: var(--transparency-2);
 }
@@ -50,7 +50,7 @@
 	display:none;
 }
 /* removes a margin bottom */
-.container-2Thooq {
+.container-3baos1 {
 	margin-bottom: 0px;
 }
 .base-3dtUhz {


### PR DESCRIPTION
Container name was changed from 2Thooq --> 3baos1 in a Discord update around July 12 2019

[transparency.css](https://github.com/Ruben7173/Ruben7173.github.io/blob/master/BetterDiscord-Themes/Modules/transparency.css) uses the old name too, but I do not use that and have not tested it.